### PR TITLE
Fix bug in i18n.h which causes program crash in i18n.cpp at line 52

### DIFF
--- a/src/i18n.h
+++ b/src/i18n.h
@@ -3,7 +3,7 @@
 #include <map>
 #include <string>
 
-enum class Language {
+enum class Language : uint32_t {
   ENGLISH,
   CHINESE,
   MAX,


### PR DESCRIPTION
背景：学习项目的过程中，选择语言时，无意间发现输入2222222222导致程序崩溃

分析原因：选择语言时，对输入进行了stoul，减一后进行static_cast<Language>。在定义Language时，未指定底层类型，默认为int。此时如果输入了ul能表示，int范围外的数字，将会static_cast后转为一个负数。既不会在stoul时抛出异常，也通过了l < Language::MAX的检查。最后在 I18n::SetLanguage(Language language)中触发断言，导致程序崩溃。

解决方案：对enum class Language指定底层类型为uint32_t，与stoul的返回类型统一