### PR TITLE
add currentCursor fgHighLight

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ bin
 .vscode
 # clang
 .cache
+.vs

--- a/src/block.cpp
+++ b/src/block.cpp
@@ -40,7 +40,7 @@ bool CBlock::isFull() const
     }
     return true;
 }
-
+/*
 void CBlock::print() const {
   std::cout << Color::Modifier(Color::BOLD, Color::BG_DEFAULT, Color::FG_RED) << PIPE << Color::Modifier()<< " ";
   for (int i = 0; i < _count; ++i) {
@@ -72,6 +72,79 @@ void CBlock::print() const {
     
   }
   std::cout << std::endl;
+}
+*/
+
+void CBlock::print(const point_t &cursor,int _row) const {
+    // 遍历每个数字，打印当前行的数据，光标所在位置高亮显示。
+    std::cout << Color::Modifier(Color::BOLD, Color::BG_DEFAULT, Color::FG_RED)
+              << PIPE << Color::Modifier() << " ";
+    for (int i = 0; i < _count; ++i) {
+        auto number = *(_numbers[i]);
+
+        // 判断当前格子是否是光标位置
+        bool isCursor =
+            (cursor.y == _row && cursor.x == i);  // 假设 _row 表示当前块的行号
+
+        // 应用背景颜色高亮显示光标位置
+        Color::Modifier bgHighlight =
+            isCursor ? Color::Modifier(Color::BOLD, Color::BG_BLUE,
+                                       Color::FG_DEFAULT)
+                     : Color::Modifier(Color::BOLD, Color::BG_DEFAULT,
+                                       Color::FG_DEFAULT);
+        Color::Modifier defaultHightlight =Color::Modifier(Color::BOLD, Color::BG_DEFAULT, Color::FG_DEFAULT);
+        Color::Code bgLight = isCursor ? Color::BG_BLUE : Color::BG_DEFAULT;
+        Color::Code fgLight = isCursor ? Color::BG_BLUE : Color::BG_DEFAULT;
+
+        if ((i + 1) % 3 == 0) {
+            if (0 == number.value) {
+                std::cout << bgHighlight << ' ';
+                std::cout << defaultHightlight
+                          << " "
+                          << Color::Modifier(Color::BOLD, Color::BG_DEFAULT,
+                                             Color::FG_RED)
+                          << PIPE << Color::Modifier() << " ";
+            } else {
+                if (number.state == State::ERASED) {
+                  std::cout << bgHighlight
+                            << Color::Modifier(Color::BOLD,bgLight,
+                                               Color::FG_GREEN)
+                            << number.value << Color::Modifier();
+                  std::cout << defaultHightlight << " "
+                            << Color::Modifier(Color::BOLD, Color::BG_DEFAULT,
+                                               Color::FG_RED)
+                            << PIPE << Color::Modifier() << " ";
+                } else {
+                  std::cout << bgHighlight << number.value;
+                  std::cout << defaultHightlight << " "
+                            << Color::Modifier(Color::BOLD, Color::BG_DEFAULT,
+                                               Color::FG_RED)
+                            << PIPE << Color::Modifier() << " ";
+                }
+            }
+        } else {
+            if (0 == number.value) {
+                std::cout << bgHighlight;
+                std::cout << Color::Modifier(Color::BOLD, bgLight,
+                                             Color::FG_DEFAULT)
+                          << ' ' << defaultHightlight << " " << PIPE << " ";
+            }
+            else {
+                if (number.state == State::ERASED) {
+                  std::cout << bgHighlight
+                            << Color::Modifier(Color::BOLD, bgLight,
+                                               Color::FG_GREEN)
+                            << number.value;
+                  std::cout << defaultHightlight << Color::Modifier() << " "
+                            << PIPE << " ";
+                } else {
+                  std::cout << bgHighlight << number.value;
+                  std::cout << defaultHightlight << " " << PIPE << " ";
+                }
+             }
+        }
+    }
+    std::cout << std::endl;
 }
 
 void CBlock::push_back(point_value_t *point)

--- a/src/block.h
+++ b/src/block.h
@@ -12,7 +12,7 @@ class CBlock
     CBlock();
     bool isValid() const;
     bool isFull() const;
-    void print() const;
+    void print(const point_t &cursor,int row) const;
     void push_back(point_value_t *point);
 
   private:

--- a/src/scene.cpp
+++ b/src/scene.cpp
@@ -36,7 +36,7 @@ void CScene::show() const
     for (int row = 0; row < _max_column; ++row)
     {
         CBlock block = _row_block[row];
-        block.print();
+        block.print(_cur_point,row);
         printUnderline(row);
     }
 }


### PR DESCRIPTION
原版本的数独当前光标仅仅用^来显示，修改后的版本用光标所在位置的蓝色高亮背景来突出光标位置。这样让游戏玩起来更加舒适，在快速移动光标时，不用费劲去寻找当前光标位置。
![e45a1f0c-f0ed-4ddb-99b3-26f6375115fe](https://github.com/user-attachments/assets/fe98eebe-48fc-4964-b4ad-73b58115b328)
![ebc3d5af-0fdf-4531-a185-39f7b7d37254](https://github.com/user-attachments/assets/b19ebc98-5cb4-4dce-b53a-ce4f874ca491)


