### PR TITLE
高亮与当前光标相同数字，方便定位观察

### DIFF
--- a/src/block.cpp
+++ b/src/block.cpp
@@ -41,12 +41,12 @@ bool CBlock::isFull() const
     return true;
 }
 
-void CBlock::print(int cur_point, char highlighted_num) const {
+void CBlock::print(int cur_point, int highlighted_num) const {
   std::cout << Color::Modifier(Color::BOLD, Color::BG_DEFAULT, Color::FG_RED) << PIPE << Color::Modifier()<< " ";
   for (int i = 0; i < _count; ++i) {
     auto number = *(_numbers[i]);
     Color::Code pipe_color, num_bgcolor, num_fgcolor;
-    char num;
+    int num;
     
     if ((i+1)%3 == 0) pipe_color = Color::FG_RED;
     else pipe_color = Color::FG_DEFAULT;
@@ -75,7 +75,7 @@ void CBlock::push_back(point_value_t *point)
     _numbers[_count++] = point;
 }
 
-char CBlock::getNumberValue(int index) const 
+int CBlock::getNumberValue(int index) const 
 {
     if (index >= 0 && index < _count) {
         return _numbers[index]->value;

--- a/src/block.cpp
+++ b/src/block.cpp
@@ -41,7 +41,7 @@ bool CBlock::isFull() const
     return true;
 }
 
-void CBlock::print(int cur_point) const {
+void CBlock::print(int cur_point, char highlighted_num) const {
   std::cout << Color::Modifier(Color::BOLD, Color::BG_DEFAULT, Color::FG_RED) << PIPE << Color::Modifier()<< " ";
   for (int i = 0; i < _count; ++i) {
     auto number = *(_numbers[i]);
@@ -50,8 +50,12 @@ void CBlock::print(int cur_point) const {
     
     if ((i+1)%3 == 0) pipe_color = Color::FG_RED;
     else pipe_color = Color::FG_DEFAULT;
+
     if (i==cur_point) num_bgcolor = Color::BG_BLUE;
+    else if (highlighted_num != UNSELECTED && number.value == highlighted_num)
+        num_bgcolor = Color::BG_YELLOW; // 与当前光标相同数字高亮为黄色
     else num_bgcolor = Color::BG_DEFAULT;
+    
     if (number.state == State::ERASED) num_fgcolor = Color::FG_GREEN;
     else num_fgcolor = Color::FG_DEFAULT;
     if (number.value == 0) num = ' ';
@@ -69,4 +73,12 @@ void CBlock::push_back(point_value_t *point)
 {
     assert(nullptr != point);
     _numbers[_count++] = point;
+}
+
+char CBlock::getNumberValue(int index) const 
+{
+    if (index >= 0 && index < _count) {
+        return _numbers[index]->value;
+    }
+    return UNSELECTED; // 或抛异常
 }

--- a/src/block.h
+++ b/src/block.h
@@ -12,8 +12,9 @@ class CBlock
     CBlock();
     bool isValid() const;
     bool isFull() const;
-    void print(int cur_point = -1) const;
+    void print(int cur_point = -1, char highlighted_num = '0') const;
     void push_back(point_value_t *point);
+    char getNumberValue(int index) const;
 
   private:
     int _count;

--- a/src/block.h
+++ b/src/block.h
@@ -12,9 +12,9 @@ class CBlock
     CBlock();
     bool isValid() const;
     bool isFull() const;
-    void print(int cur_point = -1, char highlighted_num = '0') const;
+    void print(int cur_point = -1, int highlighted_num = '0') const;
     void push_back(point_value_t *point);
-    char getNumberValue(int index) const;
+    int getNumberValue(int index) const;
 
   private:
     int _count;

--- a/src/scene.cpp
+++ b/src/scene.cpp
@@ -33,11 +33,18 @@ void CScene::show() const
 
     printUnderline();
 
+    // 获取光标位置的数字值（若光标在有效位置）
+    char highlighted_num = UNSELECTED;
+    if (_cur_point.y >= 0 && _cur_point.y < _max_column) {
+        const CBlock& cursor_block = _row_block[_cur_point.y];
+        highlighted_num = cursor_block.getNumberValue(_cur_point.x);
+    }
+
     for (int row = 0; row < _max_column; ++row)
     {
         CBlock block = _row_block[row];
-        if(_cur_point.y == row) block.print(_cur_point.x);
-        else block.print();
+        if(_cur_point.y == row) block.print(_cur_point.x, highlighted_num);
+        else block.print(-1, highlighted_num);
         printUnderline(row);
     }
 }

--- a/src/scene.cpp
+++ b/src/scene.cpp
@@ -34,7 +34,7 @@ void CScene::show() const
     printUnderline();
 
     // 获取光标位置的数字值（若光标在有效位置）
-    char highlighted_num = UNSELECTED;
+    int highlighted_num = UNSELECTED;
     if (_cur_point.y >= 0 && _cur_point.y < _max_column) {
         const CBlock& cursor_block = _row_block[_cur_point.y];
         highlighted_num = cursor_block.getNumberValue(_cur_point.x);


### PR DESCRIPTION
效果如下：
光标在数字上：
![image](https://github.com/user-attachments/assets/3dab31ab-ab00-4230-aa08-f68eafe7d80c)

光标在空格上：
![image](https://github.com/user-attachments/assets/aa3888e9-2f43-41c6-9f4f-075c2e633dc9)
