### PR TITLE
fix(common.h) : Modify redundant code(#64)

### DIFF
--- a/src/common.h
+++ b/src/common.h
@@ -54,12 +54,12 @@ struct Vim : KeyMap {
     }
 };
 
-using point_t = struct point_t {
+struct point_t {
     int x;
     int y;
 };
 
-using point_value_t = struct point_value_t {
+struct point_value_t {
     int value;
     State state;
 };


### PR DESCRIPTION
解决了滥用using导致的无效冗余代码